### PR TITLE
Switching Badges for Rockets

### DIFF
--- a/src/components/rockets/RocketsItem.css
+++ b/src/components/rockets/RocketsItem.css
@@ -35,8 +35,8 @@
   background-color: #18a2b8;
   color: white;
   border-radius: 5px;
-  padding: 0 10px;
-  display: inline-block;
+  padding: 0 5px;
+  margin-right: 10px;
 }
 
 /* Mobile View */

--- a/src/components/rockets/RocketsItem.jsx
+++ b/src/components/rockets/RocketsItem.jsx
@@ -22,7 +22,14 @@ const RocketsItem = ({ item }) => {
       />
       <div className="rocket__info-details">
         <h4 className="rocket__info-heading">{item.rocket_name}</h4>
-        <p className="rocket__info-description">{item.rocket_description}</p>
+        <div className="rocket__info-reservation-inf">
+          <p className="rocket__info-description">
+            {item.reserved && (
+              <span className="rocket__info-reserved">Reserved</span>
+            )}
+            {item.rocket_description}
+          </p>
+        </div>
         {item.reserved ? (
           <button
             type="button"

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -54,5 +54,4 @@ const rockets = createSlice({
 });
 
 export default rockets;
-
 export const { reserveRocket, cancelRocket } = rockets.actions;


### PR DESCRIPTION
In this PR,

- Show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" 
- Linter check